### PR TITLE
Switch to CuPy's top-level `is_available()`

### DIFF
--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -69,7 +69,7 @@ def setup_module(module):
     Trivial conversion call to force various one-time CUDA initialization
     operations to happen outside of benchmarks (if GPU is available).
     """
-    if cp.cuda.is_available():
+    if cp.is_available():
         print("CUDA is available, running one-time code to force initialization.")
         G = nx.karate_club_graph()
         nxcg.from_networkx(G)


### PR DESCRIPTION
This returns `False` instead of erroring on machines without GPUs.